### PR TITLE
Create new branch and run build test

### DIFF
--- a/app/lib/rag-search.ts
+++ b/app/lib/rag-search.ts
@@ -127,11 +127,11 @@ export async function performHybridSearch(
     }
 
     // データベース関数が存在しない場合のエラーメッセージをチェック
-    const isDBFunctionError = (error: any) => {
-      return error && (
-        error.message?.includes('Could not find the function') ||
-        error.message?.includes('function') && error.message?.includes('does not exist') ||
-        error.code === 'PGRST202'
+    const isDBFunctionError = (error: unknown) => {
+      return error && typeof error === 'object' && error !== null && (
+        (error as { message?: string }).message?.includes('Could not find the function') ||
+        (error as { message?: string }).message?.includes('function') && (error as { message?: string }).message?.includes('does not exist') ||
+        (error as { code?: string }).code === 'PGRST202'
       );
     };
 


### PR DESCRIPTION
Refactor `isDBFunctionError` to use `unknown` type and type guards to resolve TypeScript strict type checking error during build.

The `npm run build` command was failing due to a TypeScript error related to the use of `any` type in `app/lib/rag-search.ts`. This change replaces `any` with `unknown` and adds necessary type guards, allowing the build to complete successfully under strict type checking rules.